### PR TITLE
Make scripts in /opt/scripts executable

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -34,3 +34,6 @@ chmod -R 644 /etc/logrotate.d
 
 # permissions /opt/www
 chown -R $HL_USER_USERNAME:$HL_USER_USERNAME /opt/www
+
+# permissions /opt/scripts/*
+chmod 700 /opt/scripts/*

--- a/root/opt/scripts/deploy
+++ b/root/opt/scripts/deploy
@@ -15,7 +15,7 @@ cd /terraform/
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-apply.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-apply.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-apply.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/deploy-task
+++ b/root/opt/scripts/deploy-task
@@ -19,7 +19,7 @@ echo "$(date): terraform deploy button clicked" >>/terraform/logs/terraform-depl
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-deploy.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-deploy.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-deploy.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/destroy
+++ b/root/opt/scripts/destroy
@@ -15,7 +15,7 @@ cd /terraform/
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-destroy.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-destroy.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-destroy.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/destroy-task
+++ b/root/opt/scripts/destroy-task
@@ -18,7 +18,7 @@ sleep 2
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-destroy.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-destroy.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-destroy.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/destroy-task-background
+++ b/root/opt/scripts/destroy-task-background
@@ -11,7 +11,7 @@ sleep 2
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-destroy.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-destroy.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-destroy.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/ipaddresses
+++ b/root/opt/scripts/ipaddresses
@@ -15,7 +15,7 @@ cd /terraform/
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-ipaddresses.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-ipaddresses.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-ipaddresses.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/ipaddresses-task
+++ b/root/opt/scripts/ipaddresses-task
@@ -15,7 +15,7 @@ cd /terraform/
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-ipaddresses.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-ipaddresses.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-ipaddresses.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/log
+++ b/root/opt/scripts/log
@@ -15,7 +15,7 @@ cd /terraform/
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-logs.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-logs.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-logs.log
     echo "$(date): Unable to determine resource group variable name"

--- a/root/opt/scripts/log-task
+++ b/root/opt/scripts/log-task
@@ -15,7 +15,7 @@ cd /terraform/
 
 resource_group_name=`grep -re "^resource \"azurerm_resource_group\"" *.tf | awk -F"\"" '{print $4}'`
 if [ $? -eq 0 ]; then
-    echo "$(date): Resource group variable name is '$resource_group_name.'" >> /terraform/logs/terraform-logs.log
+    echo "$(date): Resource group variable name is '$resource_group_name'." >> /terraform/logs/terraform-logs.log
 else
     echo "$(date): Unable to determine resource group variable name" >> /terraform/logs/terraform-logs.log
     echo "$(date): Unable to determine resource group variable name"


### PR DESCRIPTION
- Explicitly set permissions on all files in /opt/scripts to 700 (to ensure they're executable by root).  
  When pushed to dockerhub and subsequently pulled, the *some* of the files in that directory were not executable.
- Fix some typos
  